### PR TITLE
Remove macOS 10.15 and add macOS 12.0

### DIFF
--- a/.github/workflows/brew-update.yml
+++ b/.github/workflows/brew-update.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11.0, macos-latest]
+        os: [macos-11.0, macos-12.0, macos-latest]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
macOS 10.15 is deprecated: https://github.com/actions/runner-images/issues/5583 .